### PR TITLE
Add Github Actions' workflow linting python code

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,40 @@
+name: Linting python code
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'app/**'
+      - 'tests/**'
+      - '.github/workflows/python-lint.yml'
+
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'tests/**'
+      - '.github/workflows/python-lint.yml'
+
+jobs:
+  python-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yapf
+
+      - name: Lint with yapf
+        run: |
+          if [ -d app ]; then python -m yapf -ipr app/; fi
+          if [ -d tests ]; then python -m yapf -ipr tests/; fi
+          test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; } 


### PR DESCRIPTION
I've prepared workflow that lints python code with `yapf`.

Workflow is started only on pushes/PRs to directories containing python code (that will be `app/` and `tests/`).

Used ready-made actions (recommended by Github Docs - both MIT licensed):
 - [`actions/checkout`](https://github.com/actions/checkout)
 - [`actions/setup-python`](https://github.com/actions/setup-python)

Closes #2 