### PR TITLE
Add CI job for running Python test and basic gitignore file

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,4 +1,4 @@
-name: Linting python code
+name: Running Python CI jobs
 
 on:
   push:
@@ -16,7 +16,7 @@ on:
       - '.github/workflows/python-lint.yml'
 
 jobs:
-  python-lint:
+  python-run:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,10 +31,15 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install yapf
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install yapf pytest pytest-cov
 
       - name: Lint with yapf
         run: |
           if [ -d app ]; then python -m yapf -ipr app/; fi
           if [ -d tests ]; then python -m yapf -ipr tests/; fi
-          test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; } 
+          test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; }
+      
+      - name: Test with pytest
+        run: |
+          pytest tests/ --cov=app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+
+.pytest_cache/
+.coverage
+
+.env
+.venv
+env/
+venv/
+ENV/


### PR DESCRIPTION
I've added Python tests check to the workflow with tests coverage analysis enabled (no report file is generated, just output in console in Github Actions - for now). Before PR I tested those CI changes on fork and it worked as I planned.

I've also included basic .gitignore.

Closes #11 