### PR TITLE
Add terminal usage and core functionalities

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Raw data image previewer."""

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -21,14 +21,6 @@ parser.add_argument("-r",
                     nargs=2,
                     default=[600, 600],
                     help="target resolution (default: %(default)s)")
-parser.add_argument("-p",
-                    "--parse",
-                    action='store_true',
-                    help="parse raw image data")
-parser.add_argument("-d",
-                    "--display",
-                    action='store_true',
-                    help="display image")
 
 args = vars(parser.parse_args())
 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Raw image data previewer - terminal functionality."""
+
+import argparse
+import os
+from .core import run_core_functionality
+
+parser = argparse.ArgumentParser(
+    prog=__package__,
+    description="preview raw data as an image of chosen format")
+parser.add_argument("FILE_PATH", help="file containing raw image data")
+parser.add_argument("-c",
+                    "--color_format",
+                    choices=["RGB3", "BGR3"],
+                    default="RGB3",
+                    help="target color format (default: %(default)s)")
+parser.add_argument("-r",
+                    "--resolution",
+                    metavar=("width", "height"),
+                    type=int,
+                    nargs=2,
+                    default=[600, 600],
+                    help="target resolution (default: %(default)s)")
+parser.add_argument("-p",
+                    "--parse",
+                    action='store_true',
+                    help="parse raw image data")
+parser.add_argument("-d",
+                    "--display",
+                    action='store_true',
+                    help="display image")
+
+args = vars(parser.parse_args())
+
+if not os.path.isfile(args["FILE_PATH"]):
+    raise Exception("Given path does not lead to a file")
+
+run_core_functionality(args)

--- a/app/core.py
+++ b/app/core.py
@@ -1,0 +1,47 @@
+"""Main functionalities."""
+
+import app.image.image as image
+import app.image.color_format as color_format
+import app.parser.factory as factory
+
+
+def run_core_functionality(args):
+
+    image = create_Image(args)
+    parser = factory.ParserFactory.create_object(
+        determine_color_format(args["color_format"]))
+
+    if args["parse"] == True:
+        image = parser.parse(image.data_buffer,
+                             determine_color_format(args["color_format"]),
+                             args["resolution"][0], args["resolution"][1])
+        if args["display"] == True:
+            displayable_data = parser.get_displayable(image)
+
+
+def create_Image(args):
+
+    raw_data = image.RawDataContainer(None).from_file(args["FILE_PATH"])
+    return image.Image(raw_data.data_buffer)
+
+
+def determine_color_format(format_string):
+
+    if format_string == "RGB3":
+        return color_format.ColorFormat(color_format.PixelFormat.RGBA,
+                                        color_format.Endianness.BIG_ENDIAN,
+                                        color_format.PixelPlane.PACKED,
+                                        8,
+                                        8,
+                                        8,
+                                        name="RGB3")
+    elif format_string == "BGR3":
+        return color_format.ColorFormat(color_format.PixelFormat.BGRA,
+                                        color_format.Endianness.BIG_ENDIAN,
+                                        color_format.PixelPlane.PACKED,
+                                        8,
+                                        8,
+                                        8,
+                                        name="BGR3")
+    else:
+        raise NotImplementedError

--- a/app/core.py
+++ b/app/core.py
@@ -1,47 +1,33 @@
 """Main functionalities."""
 
-import app.image.image as image
-import app.image.color_format as color_format
-import app.parser.factory as factory
+from .image.image import (Image, RawDataContainer)
+from .image.color_format import (RGB3_FORMAT, BGR3_FORMAT)
+from .parser.factory import ParserFactory
 
 
 def run_core_functionality(args):
 
     image = create_Image(args)
-    parser = factory.ParserFactory.create_object(
+    parser = ParserFactory.create_object(
         determine_color_format(args["color_format"]))
 
-    if args["parse"] == True:
-        image = parser.parse(image.data_buffer,
-                             determine_color_format(args["color_format"]),
-                             args["resolution"][0], args["resolution"][1])
-        if args["display"] == True:
-            displayable_data = parser.get_displayable(image)
+    image = parser.parse(image.data_buffer,
+                         determine_color_format(args["color_format"]),
+                         args["resolution"][0], args["resolution"][1])
+    displayable_data = parser.get_displayable(image)
 
 
 def create_Image(args):
 
-    raw_data = image.RawDataContainer(None).from_file(args["FILE_PATH"])
-    return image.Image(raw_data.data_buffer)
+    raw_data = RawDataContainer.from_file(args["FILE_PATH"])
+    return Image(raw_data.data_buffer)
 
 
 def determine_color_format(format_string):
 
     if format_string == "RGB3":
-        return color_format.ColorFormat(color_format.PixelFormat.RGBA,
-                                        color_format.Endianness.BIG_ENDIAN,
-                                        color_format.PixelPlane.PACKED,
-                                        8,
-                                        8,
-                                        8,
-                                        name="RGB3")
+        return RGB3_FORMAT
     elif format_string == "BGR3":
-        return color_format.ColorFormat(color_format.PixelFormat.BGRA,
-                                        color_format.Endianness.BIG_ENDIAN,
-                                        color_format.PixelPlane.PACKED,
-                                        8,
-                                        8,
-                                        8,
-                                        name="BGR3")
+        return BGR3_FORMAT
     else:
         raise NotImplementedError


### PR DESCRIPTION
I've prepared initial CLI usage functionalities.
The whole project can now be ran from the top directory by using: 'python3 -m app'. Using this command should display additional options information, as a path to a file is required. Using -h we can get information about the available options.
I've also created the "core" module which for now contains a few functions that aggregate most of the available functionalities in the project.

This is a very rough draft of how the CLI should function in the future. It's going to be developed and improved upon, when new functionalities and parsers will be added.

Closes #13 