### PR TITLE
Refactor of color_formats and definition of new one, core update

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+import cv2 as cv
 """Raw image data previewer - terminal functionality."""
 
 import argparse
 import os
-from .core import run_core_functionality
+from .core import (load_image, get_displayable)
+from .image.color_format import AVAILABLE_FORMATS
 
 parser = argparse.ArgumentParser(
     prog=__package__,
@@ -11,8 +13,8 @@ parser = argparse.ArgumentParser(
 parser.add_argument("FILE_PATH", help="file containing raw image data")
 parser.add_argument("-c",
                     "--color_format",
-                    choices=["RGB3", "BGR3"],
-                    default="RGB3",
+                    choices=AVAILABLE_FORMATS.keys(),
+                    default=list(AVAILABLE_FORMATS.keys())[0],
                     help="target color format (default: %(default)s)")
 parser.add_argument("-r",
                     "--resolution",
@@ -27,4 +29,7 @@ args = vars(parser.parse_args())
 if not os.path.isfile(args["FILE_PATH"]):
     raise Exception("Given path does not lead to a file")
 
-run_core_functionality(args)
+img = load_image(args["FILE_PATH"], args["color_format"], args['resolution'])
+cv.imshow("Displayed photo", get_displayable(img))
+cv.waitKey(0)
+cv.destroyAllWindows()

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -29,7 +29,7 @@ args = vars(parser.parse_args())
 if not os.path.isfile(args["FILE_PATH"]):
     raise Exception("Given path does not lead to a file")
 
-img = load_image(args["FILE_PATH"], args["color_format"], args['resolution'])
-cv.imshow("Displayed photo", get_displayable(img))
+img = load_image(args["FILE_PATH"], args["color_format"], args["resolution"])
+cv.imshow(args["FILE_PATH"], get_displayable(img))
 cv.waitKey(0)
 cv.destroyAllWindows()

--- a/app/core.py
+++ b/app/core.py
@@ -6,9 +6,12 @@ from .parser.factory import ParserFactory
 
 
 def load_image(file_path, color_format, resolution):
-
-    image = Image.from_file(file_path)
-    parser = ParserFactory.create_object(determine_color_format(color_format))
+    try:
+        image = Image.from_file(file_path)
+        parser = ParserFactory.create_object(
+            determine_color_format(color_format))
+    except Exception as e:
+        print(type(e).__name__, e)
 
     image = parser.parse(image.data_buffer,
                          determine_color_format(color_format), resolution[0],
@@ -20,7 +23,7 @@ def load_image(file_path, color_format, resolution):
 def get_displayable(image):
 
     if image.color_format is None:
-        raise Exception()
+        raise Exception("Image should be already parsed!")
     parser = ParserFactory.create_object(image.color_format)
 
     return parser.get_displayable(image)
@@ -31,4 +34,5 @@ def determine_color_format(format_string):
     if format_string in AVAILABLE_FORMATS.keys():
         return AVAILABLE_FORMATS[format_string]
     else:
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "Provided string is not name of supported format.")

--- a/app/core.py
+++ b/app/core.py
@@ -1,33 +1,34 @@
 """Main functionalities."""
 
 from .image.image import (Image, RawDataContainer)
-from .image.color_format import (RGB3_FORMAT, BGR3_FORMAT)
+from .image.color_format import AVAILABLE_FORMATS
 from .parser.factory import ParserFactory
 
 
-def run_core_functionality(args):
+def load_image(file_path, color_format, resolution):
 
-    image = create_Image(args)
-    parser = ParserFactory.create_object(
-        determine_color_format(args["color_format"]))
+    image = Image.from_file(file_path)
+    parser = ParserFactory.create_object(determine_color_format(color_format))
 
     image = parser.parse(image.data_buffer,
-                         determine_color_format(args["color_format"]),
-                         args["resolution"][0], args["resolution"][1])
-    displayable_data = parser.get_displayable(image)
+                         determine_color_format(color_format), resolution[0],
+                         resolution[1])
+
+    return image
 
 
-def create_Image(args):
+def get_displayable(image):
 
-    raw_data = RawDataContainer.from_file(args["FILE_PATH"])
-    return Image(raw_data.data_buffer)
+    if image.color_format is None:
+        raise Exception()
+    parser = ParserFactory.create_object(image.color_format)
+
+    return parser.get_displayable(image)
 
 
 def determine_color_format(format_string):
 
-    if format_string == "RGB3":
-        return RGB3_FORMAT
-    elif format_string == "BGR3":
-        return BGR3_FORMAT
+    if format_string in AVAILABLE_FORMATS.keys():
+        return AVAILABLE_FORMATS[format_string]
     else:
-        raise NotImplementedError
+        raise NotImplementedError()

--- a/app/image/color_format.py
+++ b/app/image/color_format.py
@@ -61,20 +61,24 @@ class ColorFormat():
             "Provided value should be an iterable of 3 or 4 values!")
 
     def __str__(self):
-        return name
+        return self.name
 
 
-RGB3_FORMAT = ColorFormat(PixelFormat.RGBA,
-                          Endianness.BIG_ENDIAN,
-                          PixelPlane.PACKED,
-                          8,
-                          8,
-                          8,
-                          name="RGB3")
-BGR3_FORMAT = ColorFormat(PixelFormat.BGRA,
-                          Endianness.BIG_ENDIAN,
-                          PixelPlane.PACKED,
-                          8,
-                          8,
-                          8,
-                          name="BGR3")
+AVAILABLE_FORMATS = {
+    'RGB3':
+    ColorFormat(PixelFormat.RGBA,
+                Endianness.BIG_ENDIAN,
+                PixelPlane.PACKED,
+                8,
+                8,
+                8,
+                name="RGB3"),
+    'BGR3':
+    ColorFormat(PixelFormat.BGRA,
+                Endianness.BIG_ENDIAN,
+                PixelPlane.PACKED,
+                8,
+                8,
+                8,
+                name="BGR3")
+}

--- a/app/image/color_format.py
+++ b/app/image/color_format.py
@@ -65,20 +65,45 @@ class ColorFormat():
 
 
 AVAILABLE_FORMATS = {
-    'RGB3':
+    'RGB24':
     ColorFormat(PixelFormat.RGBA,
                 Endianness.BIG_ENDIAN,
                 PixelPlane.PACKED,
                 8,
                 8,
                 8,
-                name="RGB3"),
-    'BGR3':
+                name="RGB24"),
+    'BGR24':
     ColorFormat(PixelFormat.BGRA,
                 Endianness.BIG_ENDIAN,
                 PixelPlane.PACKED,
                 8,
                 8,
                 8,
-                name="BGR3")
+                name="BGR24"),
+    'RGB32':
+    ColorFormat(PixelFormat.RGBA,
+                Endianness.BIG_ENDIAN,
+                PixelPlane.PACKED,
+                8,
+                8,
+                8,
+                8,
+                name="RGB32"),
+    'RGB332':
+    ColorFormat(PixelFormat.RGBA,
+                Endianness.LITTLE_ENDIAN,
+                PixelPlane.PACKED,
+                3,
+                3,
+                2,
+                name="RGB332"),
+    'RGB565':
+    ColorFormat(PixelFormat.RGBA,
+                Endianness.LITTLE_ENDIAN,
+                PixelPlane.PACKED,
+                5,
+                6,
+                5,
+                name="RGB565")
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+opencv-python

--- a/tests/color_format_test.py
+++ b/tests/color_format_test.py
@@ -10,7 +10,7 @@ class TestColorFormat(unittest.TestCase):
                                            8,
                                            8,
                                            8,
-                                           name="RGB3")
+                                           name="RGB24")
 
     def test_bpcs_setter(self):
         self.color_format.bits_per_components = (8, 8, 8, 0)

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -11,7 +11,7 @@ class TestImageClass(unittest.TestCase):
                                           "resources/BGR3_1280_720")
         self.empty_img = image.Image(None)
         with open(self.TEST_FILE_BGR, "rb") as file:
-            self.img = image.Image(file.read(), cf.AVAILABLE_FORMATS['BGR3'],
+            self.img = image.Image(file.read(), cf.AVAILABLE_FORMATS['BGR24'],
                                    numpy.zeros((720, 1280, 3)))
 
     def test_from_file(self):

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -11,7 +11,7 @@ class TestImageClass(unittest.TestCase):
                                           "resources/BGR3_1280_720")
         self.empty_img = image.Image(None)
         with open(self.TEST_FILE_BGR, "rb") as file:
-            self.img = image.Image(file.read(), cf.BGR3_FORMAT,
+            self.img = image.Image(file.read(), cf.AVAILABLE_FORMATS['BGR3'],
                                    numpy.zeros((720, 1280, 3)))
 
     def test_from_file(self):


### PR DESCRIPTION
I've changed the way of storing built-in color formats and defined some of them, moreover fixed `core.py` and `main.py`.

Now built-in formats in `image/color_format.py` are stored in a dictionary, so it's possible to get all available formats 
as dict keys, also default color format is not hard coded.  Additionally defined `RGB32` `RGB332` `RGB565` formats - they're tested on images from `tests/resources`.

Now `core.py`  functions return appropriate images objects so they can be displayed using `openCV`.
Updated tests due to `color_format` changes. 

Closes #21 