### PR TITLE
Height no longer required as CLI argument. Filepath made optional, app starts without arguments.

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from tkinter import StringVar
 import cv2 as cv
 """Raw image data previewer - terminal functionality."""
 
@@ -11,7 +12,10 @@ from .gui import MainWindow
 parser = argparse.ArgumentParser(
     prog=__package__,
     description="preview raw data as an image of chosen format")
-parser.add_argument("FILE_PATH", help="file containing raw image data")
+parser.add_argument("-f",
+                    "--FILE_PATH",
+                    help="file containing raw image data",
+                    default=None)
 parser.add_argument("-c",
                     "--color_format",
                     choices=AVAILABLE_FORMATS.keys(),
@@ -19,16 +23,17 @@ parser.add_argument("-c",
                     help="target color format (default: %(default)s)")
 parser.add_argument("-r",
                     "--resolution",
-                    metavar=("width", "height"),
+                    metavar=("width"),
                     type=int,
-                    nargs=2,
-                    default=[600, 600],
+                    nargs=1,
+                    default=600,
                     help="target resolution (default: %(default)s)")
 
 args = vars(parser.parse_args())
 
-if not os.path.isfile(args["FILE_PATH"]):
-    raise Exception("Given path does not lead to a file")
+if isinstance(args["FILE_PATH"], str):
+    if not os.path.isfile(args["FILE_PATH"]):
+        raise Exception("Given path does not lead to a file")
 
 #img = load_image(args["FILE_PATH"], args["color_format"], args["resolution"])
 app = MainWindow(args)

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from tkinter import StringVar
 import cv2 as cv
 """Raw image data previewer - terminal functionality."""
 
@@ -21,13 +20,13 @@ parser.add_argument("-c",
                     choices=AVAILABLE_FORMATS.keys(),
                     default=list(AVAILABLE_FORMATS.keys())[0],
                     help="target color format (default: %(default)s)")
-parser.add_argument("-r",
-                    "--resolution",
+parser.add_argument("-w",
+                    "--width",
                     metavar=("width"),
                     type=int,
                     nargs=1,
                     default=600,
-                    help="target resolution (default: %(default)s)")
+                    help="target width (default: %(default)s)")
 
 args = vars(parser.parse_args())
 

--- a/app/core.py
+++ b/app/core.py
@@ -5,7 +5,7 @@ from .image.color_format import AVAILABLE_FORMATS
 from .parser.factory import ParserFactory
 
 
-def load_image(file_path, color_format, resolution):
+def load_image(file_path, color_format, width):
     try:
         image = Image.from_file(file_path)
         parser = ParserFactory.create_object(
@@ -14,8 +14,7 @@ def load_image(file_path, color_format, resolution):
         print(type(e).__name__, e)
 
     image = parser.parse(image.data_buffer,
-                         determine_color_format(color_format), resolution[0],
-                         resolution[1])
+                         determine_color_format(color_format), width)
 
     return image
 

--- a/app/gui.py
+++ b/app/gui.py
@@ -16,7 +16,7 @@ class MainWindow(tk.Frame):
         self.frm_image = tk.Label(self.master, bg=self.bg_color)
         self.frm_image.pack(fill=tk.BOTH, side=tk.LEFT, expand=True)
         self.pack()
-        self.init_width = args["resolution"]
+        self.init_width = args["width"]
         self.path_to_File = args["FILE_PATH"]
         self.init_color_format = args["color_format"]
         self.widget_font = tkFont.Font(family='Gill Sans MT',

--- a/app/gui.py
+++ b/app/gui.py
@@ -16,22 +16,24 @@ class MainWindow(tk.Frame):
         self.frm_image = tk.Label(self.master, bg=self.bg_color)
         self.frm_image.pack(fill=tk.BOTH, side=tk.LEFT, expand=True)
         self.pack()
-        self.init_width = args["resolution"][0]
-        self.init_height = args["resolution"][1]
+        self.init_width = args["resolution"]
         self.path_to_File = args["FILE_PATH"]
         self.init_color_format = args["color_format"]
         self.widget_font = tkFont.Font(family='Gill Sans MT',
                                        size=10,
                                        weight=tkFont.NORMAL)
         self.img_tk = None
-        self.create_image()
+        if self.path_to_File != None:
+            self.create_image()
         self.create_widgets(args)
 
     def create_image(self):
-        resolution = [self.init_width, self.init_height]
-        img = load_image(self.path_to_File, self.init_color_format, resolution)
+        img = load_image(self.path_to_File, self.init_color_format,
+                         self.init_width)
         self.img_tk = Image.fromarray(get_displayable(img))
         img_tk = ImageTk.PhotoImage(image=self.img_tk)
+        resolution = [self.img_tk.width, self.img_tk.height]
+        self.init_height = self.img_tk.height
         self.frm_image.img_tk = img_tk
         self.frm_image.config(image=img_tk)
         resolution_string = str(resolution[0] +
@@ -44,14 +46,18 @@ class MainWindow(tk.Frame):
             raise Exception("Given path does not lead to a file")
 
     def update_image(self):
-        resolution = [int(self.ent_width.get()), int(self.ent_height.get())]
-        img = load_image(self.path_to_File, self.v.get(), resolution)
+        img = load_image(self.path_to_File, self.v.get(),
+                         int(self.ent_width.get()))
         self.img_tk = Image.fromarray(get_displayable(img))
         img_tk = ImageTk.PhotoImage(image=self.img_tk)
+        self.ent_height.delete(0, len(self.ent_height.get()))
+        self.ent_width.delete(0, len(self.ent_width.get()))
+        self.ent_width.insert(0, self.img_tk.width)
+        self.ent_height.insert(0, self.img_tk.height)
         self.frm_image.img_tk = img_tk
         self.frm_image.config(image=img_tk)
-        resolution_string = str(resolution[0] +
-                                200) + "x" + str(resolution[1] + 20)
+        resolution_string = str(int(self.ent_width.get()) + 200) + "x" + str(
+            int(self.ent_height.get()) + 20)
         self.master.geometry(resolution_string)
 
     def create_widgets(self, args):
@@ -127,11 +133,17 @@ class MainWindow(tk.Frame):
         self.ent_width = tk.Entry(master=frm_width,
                                   width=10,
                                   font=self.widget_font)
-        self.ent_width.insert(0, self.img_tk.width)
+
         self.ent_height = tk.Entry(master=frm_height,
                                    width=10,
                                    font=self.widget_font)
-        self.ent_height.insert(0, self.img_tk.height)
+
+        if self.path_to_File != None:
+            self.ent_width.insert(0, self.img_tk.width)
+            self.ent_height.insert(0, self.img_tk.height)
+        else:
+            self.ent_width.insert(0, 0)
+            self.ent_height.insert(0, 0)
         self.ent_height.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         self.ent_width.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         frm_size.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)


### PR DESCRIPTION
Height has been removed from CLI arguments, necessary changes to core were made.
To make the filepath argument optional, there are few places in GUI where the filepath is checked, whether it's null. Additionally tkninter entries responsible for height and width have initial values set to 0 if there is no path, their values are cleared and set in the update image function.