### PR TITLE
Add export to higher formats files

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -4,7 +4,7 @@ import cv2 as cv
 
 import argparse
 import os
-from .core import (load_image, get_displayable)
+from .core import (save_image_as_file, get_displayable, load_image)
 from .image.color_format import AVAILABLE_FORMATS
 from .gui import MainWindow
 
@@ -24,15 +24,24 @@ parser.add_argument("-r",
                     nargs=2,
                     default=[600, 600],
                     help="target resolution (default: %(default)s)")
+parser.add_argument(
+    "-e",
+    "--export",
+    metavar="RESULT_PATH",
+    help="destination file for parsed image, and it's extension")
 
 args = vars(parser.parse_args())
 
 if not os.path.isfile(args["FILE_PATH"]):
     raise Exception("Given path does not lead to a file")
 
-#img = load_image(args["FILE_PATH"], args["color_format"], args["resolution"])
-app = MainWindow(args)
-app.mainloop()
+if args["export"] is None:
+    app = MainWindow(args)
+    app.mainloop()
+else:
+    img = load_image(args["FILE_PATH"], args["color_format"],
+                     args["resolution"])
+    save_image_as_file(get_displayable(img), args["export"])
 """
 cv.imshow(args["FILE_PATH"], get_displayable(img))
 cv.waitKey(0)

--- a/app/core.py
+++ b/app/core.py
@@ -3,6 +3,8 @@
 from .image.image import (Image, RawDataContainer)
 from .image.color_format import AVAILABLE_FORMATS
 from .parser.factory import ParserFactory
+import cv2 as cv
+import os
 
 
 def load_image(file_path, color_format, resolution):
@@ -16,7 +18,6 @@ def load_image(file_path, color_format, resolution):
     image = parser.parse(image.data_buffer,
                          determine_color_format(color_format), resolution[0],
                          resolution[1])
-
     return image
 
 
@@ -36,3 +37,20 @@ def determine_color_format(format_string):
     else:
         raise NotImplementedError(
             "Provided string is not name of supported format.")
+
+
+def save_image_as_file(image, file_path):
+
+    directory = file_path.replace('\\', '/')
+    if directory.rfind('/') == -1:
+        directory = './'
+    else:
+        directory = directory[:directory.rfind("/")]
+
+    if not os.path.isdir(directory):
+        os.makedirs(directory)
+
+    try:
+        cv.imwrite(file_path, cv.cvtColor(image, cv.COLOR_RGB2BGR))
+    except Exception as e:
+        print(type(e).__name__, e)


### PR DESCRIPTION
I've created function which saves parsed image to file and added argument for CLI usage.
Formats not supported by OpenCV are handled - proper exception is shown.
GUI doesn't start when using --export option.