### PR TITLE
Readme: add python3-pil.imagetk package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install -r requirements.txt
 ### Ubuntu 20.04
 
 ```bash
-sudo apt-get install python3-pip git
+sudo apt-get install python3-pip git python3-pil.imagetk
 git clone https://github.com/antmicro-labs/raw-image-data-previewer.git
 cd raw-image-data-previewer
 python3 -m pip install -r requirements.txt


### PR DESCRIPTION
Installing `Pillow` which is listed in `requirements.txt` does not provide `PIL.ImageTk`.
Without `python3-pil.imagetk` package on Ubuntu 20 you can `import PIL`, but not `from PIL import ImageTk`.

It's mentioned here:
https://stackoverflow.com/a/48170806/7809590
I've checked this on Ubuntu and haven't found a corresponding package in pypi.