### PR TITLE
Recalculate width change instantly

### DIFF
--- a/app/canvas.py
+++ b/app/canvas.py
@@ -26,8 +26,6 @@ class AutoScrollbar(ttk.Scrollbar):
 class CanvasImage:
     """ Canvas that displays an image, allowing zooming and dragging. """
     def __init__(self, placeholder, path, color_format, width):
-        # How zoomed in the image is at the begginnig.
-        self.imscale = 1.0
         # How much the zoom changes based on scrolling etc.
         self.__zoom_delta = 1.3
         self.__filter = Image.ANTIALIAS
@@ -78,6 +76,16 @@ class CanvasImage:
         self.__huge_size = 14000
         # Max bandwith is set at 1024.
         self.__band_width = 1024
+        self.reset_width()
+        self.canvas.focus_set()
+
+    def set_width(self, width):
+        self.img.reshape(width)
+        self.reset_width()
+
+    def reset_width(self):
+        # How zoomed in the image is at the begginnig.
+        self.imscale = 1.0
         # Open our image.
         self.__image = Image.fromarray(get_displayable(self.img))
         # Image width and height, public for outer classes.
@@ -118,7 +126,6 @@ class CanvasImage:
         self.container = self.canvas.create_rectangle(
             (0, 0, self.imwidth, self.imheight), width=0)
         self.__show_image()
-        self.canvas.focus_set()
 
     def set_antialiasing(self, antialiasing):
         if antialiasing:

--- a/app/gui.py
+++ b/app/gui.py
@@ -73,6 +73,14 @@ class MainWindow(tk.Frame):
             self.var_height.set(self.canvas.imheight)
             self.canvas.grid()
 
+    def update_width(self):
+        if not self.canvas:
+            self.update_image()
+            return
+        self.canvas.set_width(int(self.ent_width.get()))
+        self.var_width.set(self.canvas.imwidth)
+        self.var_height.set(self.canvas.imheight)
+
     def show_color_info_popup(self):
         pop = tk.Toplevel(self.master)
         pop.title("Color format description")
@@ -198,7 +206,7 @@ class MainWindow(tk.Frame):
                                     validate=tk.ALL,
                                     validatecommand=(validator, '%P'),
                                     textvariable=self.var_width)
-        self.ent_width.bind('<Return>', (lambda _: self.update_image()))
+        self.ent_width.bind('<Return>', (lambda _: self.update_width()))
 
         self.ent_height = tk.Entry(master=frm_height,
                                    width=10,

--- a/app/image/image.py
+++ b/app/image/image.py
@@ -47,3 +47,16 @@ class Image(RawDataContainer):
         self.processed_data = processed_data
         self.width = width
         self.height = height
+        self.orig_size = None
+
+    def reshape(self, new_width):
+        if self.orig_size is None:
+            self.orig_size = self.width * self.height
+            self.pixel_size = self.processed_data.size / self.orig_size
+            self.orig_processed_data = self.processed_data
+        new_height = self.orig_size // new_width
+        self.processed_data = self.orig_processed_data[:round(new_width *
+                                                              new_height *
+                                                              self.pixel_size)]
+        self.height = new_height
+        self.width = new_width


### PR DESCRIPTION
Reuse file data that is already read into a numpy array, and only slice it later (which is a 0-copy operation).
Do this in the Image class, so that it works for every filter.

The image height is rounded down.  Another option would be to round the height up, but it would require disabling initial zero-padding in all the filters, and either unifying the subsequent one (get_displayable), or removing it too, and moving it to the Image resizing function.  Then we could keep a numpy array large enough to hold all the resizes so far, in order to avoid excessive (de)allocations.

Closes #43